### PR TITLE
Move staging to 6.1

### DIFF
--- a/_config
+++ b/_config
@@ -6,6 +6,12 @@ Patterntype: none
 Required: perl-YAML-LibYAML
 %endif
 
+%if "%_repository" == "containerkiwi"
+Type: kiwi
+Repotype: slepool:nobuildid
+Patterntype: none
+%endif
+
 # Container images are build in 'containers' repository
 # ISO images are build in 'containers' repository too
 %if %_repository == "containers"
@@ -25,15 +31,14 @@ Type: docker
 BuildEngine: docker
 
 Prefer: registries-conf-suse
-Prefer: sles-release
 Prefer: kernel-default
 %endif
 
 %if %_repository == "containers" || "%_repository" == "charts"
 Macros:
 %img_repo %(echo registry.opensuse.org:%{_project}:containers | tr ":" "/" | tr '[:upper:]' '[:lower:]')
-%slmicro_version 6.0
+%slmicro_version 6.1
 :Macros
 
-BuildFlags: dockerarg:SLMICRO_VERSION=6.0
+BuildFlags: dockerarg:SLMICRO_VERSION=6.1
 %endif

--- a/suse-toolbox-image.dummy/LICENSE
+++ b/suse-toolbox-image.dummy/LICENSE
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/suse-toolbox-image.dummy/_constraints
+++ b/suse-toolbox-image.dummy/_constraints
@@ -1,0 +1,13 @@
+<constraints>
+  <overwrite>
+    <conditions>
+      <arch>ppc64le</arch>
+    </conditions>
+    <hardware>
+      <disk>
+        <size unit="G">4</size>
+      </disk>
+    </hardware>
+  </overwrite>
+</constraints>
+

--- a/suse-toolbox-image.dummy/_service
+++ b/suse-toolbox-image.dummy/_service
@@ -1,0 +1,10 @@
+<services>
+    <service mode="buildtime" name="kiwi_metainfo_helper"/>
+    <service name="replace_using_package_version" mode="buildtime">
+        <param name="file">suse-toolbox-image.kiwi</param>
+        <param name="regex">%PKG_VERSION%</param>
+        <param name="parse-version">patch</param>
+        <param name="package">gdb</param>
+    </service>
+    <service mode="buildtime" name="kiwi_label_helper"/>
+</services>

--- a/suse-toolbox-image.dummy/config.sh
+++ b/suse-toolbox-image.dummy/config.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+set -euo pipefail
+
+
+echo "Configure image: [$kiwi_iname]..."
+
+#======================================
+## Import repositories' keys
+##--------------------------------------
+suseImportBuildKey
+
+
+#======================================
+# Include docs intallation
+#--------------------------------------
+sed -i 's/.*rpm.install.excludedocs.*/rpm.install.excludedocs = no/g' /etc/zypp/zypp.conf
+
+exit 0

--- a/suse-toolbox-image.dummy/suse-toolbox-image.kiwi
+++ b/suse-toolbox-image.dummy/suse-toolbox-image.kiwi
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- OBS-Imagerepo: obsrepositories:/ -->
+
+<image schemaversion="7.4" name="suse-toolbox-image">
+    <description type="system">
+        <author>David Cassany</author>
+        <contact>dcassany@suse.com</contact>
+        <specification>Image to mock suse-toolbox image in Elemental development environment</specification>
+    </description>
+    <preferences>
+        <type image="docker">
+            <containerconfig name="suse/sl-micro/6.1/toolbox" tag="latest" additionaltags="%PKG_VERSION%,%PKG_VERSION%-%RELEASE%" maintainer="David Cassany &lt;dcassany@suse.com&gt;">
+                <subcommand execute="/bin/bash"/>
+            </containerconfig>
+        </type>
+        <version>1.0.0</version>
+        <packagemanager>zypper</packagemanager>
+        <rpm-excludedocs>false</rpm-excludedocs>
+    </preferences>
+    <repository>
+        <source path="obsrepositories:/"/>
+    </repository>
+    <packages type="bootstrap">
+        <package name="ca-certificates"/>
+        <package name="ca-certificates-mozilla"/>
+        <package name="container-suseconnect"/>
+        <package name="coreutils"/>
+        <package name="curl"/>
+        <package name="suse-build-key"/>
+        <package name="timezone"/>
+        <package name="netcfg"/>
+        <package name="aaa_base"/>
+        <package name="cracklib-dict-small"/>
+        <package name="filesystem"/>
+        <package name="rpm"/>
+        <package name="shadow"/>
+        <package name="zypper"/>
+        <package name="gdb"/>
+        <package name="glibc-locale"/>
+        <package name="strace"/>
+        <package name="ltrace"/>
+        <package name="traceroute"/>
+        <package name="iputils"/>
+        <package name="supportutils"/>
+        <package name="vim"/>
+        <package name="less"/>
+        <package name="man"/>
+        <package name="sudo"/>
+        <package name="system-group-wheel"/>
+        <package name="libcap-progs"/>
+        <package name="procps"/>
+    </packages>
+</image>


### PR DESCRIPTION
This moves staging to build against SL Micro 6.1 and uses a dummy toolbox image to bootstrap images. The only changes are in project configuration and the additional images in a separate commit each.