### PR TITLE
Move to SL Micro 6.2

### DIFF
--- a/_config
+++ b/_config
@@ -32,6 +32,7 @@ Macros:
 :Macros
 
 BuildFlags: dockerarg:SLMICRO_VERSION=6.2
+BuildFlags: dockerarg:SL_VERSION=16.0
 %endif
 
 # Fix choice (go1.22 vs go1.22-openssl) for helm


### PR DESCRIPTION
This commits sets SL Micro 6.2 as the base code stream.

In addition, it removes the RPi setup to build disks as this is no longer required, it can be done form the UI.