### PR TITLE
Require kernel-default in the build env

### DIFF
--- a/_config
+++ b/_config
@@ -31,7 +31,9 @@ Type: docker
 BuildEngine: docker
 
 Prefer: registries-conf-suse
-Prefer: kernel-default
+
+# Docker build env requires kernel default to apply iptables
+Required: kernel-default
 %endif
 
 %if %_repository == "containers" || "%_repository" == "charts"


### PR DESCRIPTION
This commit requires kernel-default in the build environment. Docker engine requires it otherwise it fails with:

'Extension addrtype revision 0 not supported, missing kernel module?'