### PR TITLE
Switch from staging to maintenance 6.2

### DIFF
--- a/.github/workflows/update_sources.yaml
+++ b/.github/workflows/update_sources.yaml
@@ -6,7 +6,7 @@ on:
       target_branch:
         description: 'Target branch to upgrade in OBS'
         required: true
-        default: 'dev'
+        default: 'maintenance_6.2'
       source_repositories:
         description: 'Source repositories to upgrade from'
         required: true

--- a/config.yaml
+++ b/config.yaml
@@ -1,29 +1,7 @@
 # Sets the relation of branches in current repository with
 # source repositories branches
 
-dev:
-- repo: rancher/elemental-toolkit
-  branch: main
-  parseVersion: patch
-  versionOffset: no
-- repo: rancher/elemental-operator
-  branch: main
-  parseVersion: patch
-  versionOffset: no
-- repo: rancher/elemental
-  branch: main
-  parseVersion: patch
-  versionOffset: no
-- repo: rancher-sandbox/cluster-api-provider-elemental
-  branch: main
-  parseVersion: patch
-  versionOffset: no
-- repo: rancher/elemental-channels
-  branch: main
-  parseVersion: none
-  versionOffset: no
-
-staging:
+maintenance_6.2:
 - repo: rancher/elemental-toolkit
   branch: v2.3.x
   parseVersion: patch


### PR DESCRIPTION
This commit drops the setup for 'dev' brancha is this is no longer in use and switches from 'staging' to the new 'maintenance_6.2' branch.